### PR TITLE
Fix pin tracer segfault when using `-w`

### DIFF
--- a/tracers/pin/ImageManager.cpp
+++ b/tracers/pin/ImageManager.cpp
@@ -57,6 +57,10 @@ BOOL ImageManager::isInterestingAddress(ADDRINT addr)
         }
 
         auto i = images.upper_bound(LoadedImage("", addr));
+        if (i == images.begin()) {
+            PIN_RWMutexUnlock(&images_lock);
+            return false;
+        }
         --i;
 
         // If the instruction address does not fall inside a valid white listed image, bail out.


### PR DESCRIPTION
If `i` is the first image, then `--i` causes segfault.